### PR TITLE
Read amount of samples stored in FIFO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,12 @@ where
         Ok(())
     }
 
+    /// Get the amount of samples currently stored in the FIFO queue
+    pub fn get_stored_samples(&mut self) -> Result<u8, Error<E>> {
+        let value = self.read_reg(Register::FIFO_SRC_REG)?;
+        Ok(value & FSS)
+    }
+
     /// FIFO overrun on `INT1` pin,
     /// `CTRL_REG3`: `I1_OVERRUN`
     pub fn enable_i1_overrun(&mut self, enable: bool) -> Result<(), Error<E>> {
@@ -563,6 +569,18 @@ where
             w,
             "INT1_THS (32h) = {:#010b}",
             self.read_reg(Register::INT1_THS)?
+        )
+        .unwrap();
+        writeln!(
+            w,
+            "FIFO_SRC_REG (2Fh) = {:#010b}",
+            self.read_reg(Register::FIFO_SRC_REG)?
+        )
+        .unwrap();
+        writeln!(
+            w,
+            "FIFO_CTRL_REG (2Fh) = {:#010b}",
+            self.read_reg(Register::FIFO_CTRL_REG)?
         )
         .unwrap();
         Ok(())

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -233,6 +233,10 @@ pub enum FifoMode {
 
 pub const FTH_MASK: u8 = 0b0001_1111;
 
+// === FIFO_SRC_REG (2Fh) ===
+
+pub const FSS: u8 = 0b0001_1111;
+
 // === INT1_CFG (30h), INT2_CFG (34h) ===
 
 pub const AOI_6D_MASK: u8 = 0b1100_0000;


### PR DESCRIPTION
Add functionality for reading the amount of samples that are currently stored in the FIFO queue. Can be used if/when you want to read all of the values out of the FIFO, without always trying to read 32 of them.

Print out the FIFO registers when dumping registers.