### PR TITLE
Fix the no_std problem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ out_f32 = ["num-traits", "num-derive"]
 [dependencies]
 accelerometer = "0.12.0"
 embedded-hal = "0.2.5"
-num-traits = { version = "0.2.14", optional = true }
+num-traits = { version = "0.2.14", optional = true, default-features = false }
 num-derive = { version = "0.3.3", optional = true }
 
 [dependencies.cast]


### PR DESCRIPTION
I'm testing the crate with nRF52840 MCU, no_std. It wouldn't compile with the out_f32, and the reason is the num-traits, with has std as a dependency, unless default-features are set to false: https://docs.rs/crate/num-traits/0.2.14

Long term goal: modify the sample_rate function, which seems to be the only one requiring FromPrimitive trait, and therefore remove the need for a separate out_f32 feature: what do you think?

